### PR TITLE
PEG-2848: Bump pom to -PEG-2848-R-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
     <artifactId>stagingbulkscan-parent</artifactId>
-    <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+    <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>StagingBulkScan Context - Parent Module</name>

--- a/stagingbulkscan-azure-core/pom.xml
+++ b/stagingbulkscan-azure-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-azure-functions/pom.xml
+++ b/stagingbulkscan-azure-functions/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <artifactId>stagingbulkscan-azure-functions</artifactId>
     <packaging>jar</packaging>

--- a/stagingbulkscan-command/pom.xml
+++ b/stagingbulkscan-command/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-command/stagingbulkscan-command-api/pom.xml
+++ b/stagingbulkscan-command/stagingbulkscan-command-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-command</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-command/stagingbulkscan-command-handler/pom.xml
+++ b/stagingbulkscan-command/stagingbulkscan-command-handler/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-command</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-domain/pom.xml
+++ b/stagingbulkscan-domain/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-domain/stagingbulkscan-domain-aggregate/pom.xml
+++ b/stagingbulkscan-domain/stagingbulkscan-domain-aggregate/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
         <artifactId>stagingbulkscan-domain</artifactId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <artifactId>stagingbulkscan-domain-aggregate</artifactId>
 

--- a/stagingbulkscan-domain/stagingbulkscan-domain-common/pom.xml
+++ b/stagingbulkscan-domain/stagingbulkscan-domain-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
         <artifactId>stagingbulkscan-domain</artifactId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <artifactId>stagingbulkscan-domain-common</artifactId>
 

--- a/stagingbulkscan-domain/stagingbulkscan-domain-event/pom.xml
+++ b/stagingbulkscan-domain/stagingbulkscan-domain-event/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-domain</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-event-sources/pom.xml
+++ b/stagingbulkscan-event-sources/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-event/pom.xml
+++ b/stagingbulkscan-event/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/stagingbulkscan-event/stagingbulkscan-event-listener/pom.xml
+++ b/stagingbulkscan-event/stagingbulkscan-event-listener/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-event</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-event/stagingbulkscan-event-processor/pom.xml
+++ b/stagingbulkscan-event/stagingbulkscan-event-processor/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-event</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-healthchecks/pom.xml
+++ b/stagingbulkscan-healthchecks/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-integration-test/pom.xml
+++ b/stagingbulkscan-integration-test/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-json/pom.xml
+++ b/stagingbulkscan-json/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-query/pom.xml
+++ b/stagingbulkscan-query/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
         <artifactId>stagingbulkscan-parent</artifactId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>stagingbulkscan-query</artifactId>

--- a/stagingbulkscan-query/stagingbulkscan-query-api/pom.xml
+++ b/stagingbulkscan-query/stagingbulkscan-query-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
         <artifactId>stagingbulkscan-query</artifactId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>war</packaging>

--- a/stagingbulkscan-query/stagingbulkscan-query-view/pom.xml
+++ b/stagingbulkscan-query/stagingbulkscan-query-view/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
         <artifactId>stagingbulkscan-query</artifactId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/stagingbulkscan-service/pom.xml
+++ b/stagingbulkscan-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-testharness/pom.xml
+++ b/stagingbulkscan-testharness/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
 
     <artifactId>stagingbulkscan-testharness</artifactId>

--- a/stagingbulkscan-viewstore/pom.xml
+++ b/stagingbulkscan-viewstore/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-parent</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-viewstore/stagingbulkscan-viewstore-liquibase/pom.xml
+++ b/stagingbulkscan-viewstore/stagingbulkscan-viewstore-liquibase/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-viewstore</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/stagingbulkscan-viewstore/stagingbulkscan-viewstore-persistence/pom.xml
+++ b/stagingbulkscan-viewstore/stagingbulkscan-viewstore-persistence/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>stagingbulkscan-viewstore</artifactId>
         <groupId>uk.gov.moj.cpp.stagingbulkscan</groupId>
-        <version>17.103.44-RBSD-2609-SNAPSHOT</version>
+        <version>17.103.44-PEG-2848-R-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Bumps pom versions to -PEG-2848-R-SNAPSHOT for R-candidate build.