### PR TITLE
PEG-2848: Sync pom properties with team/release-engg-2609

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <sonar.report.export.path>sonar-report.json</sonar.report.export.path>
         <sonar.scm.provider>git</sonar.scm.provider>
         <mvn.site.url>file://${project.build.directory}/site</mvn.site.url>
-        <core-domain.version>17.103.10</core-domain.version>
+        <core-domain.version>17.104.3</core-domain.version>
         <prosecutioncasefile-version>17.0.11</prosecutioncasefile-version>
         <sjp-version>17.103.167</sjp-version>
         <stream-transformation-tool-anonymise.version>7.0.0</stream-transformation-tool-anonymise.version>


### PR DESCRIPTION
## Summary
Syncs this repo's `pom.xml` `<properties>` version entries with `team/release-engg-2609`.

## Changes
```
-        <core-domain.version>17.103.10</core-domain.version>
+        <core-domain.version>17.104.3</core-domain.version>
```

## Why
Part of a 28-repo effort to bring `team/PEG-2848-R` into version-alignment with the passing `release-engg-2609` configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)